### PR TITLE
Editor context menu "copy" fix

### DIFF
--- a/pgmanage/app/static/assets/js/pgmanage_frontend/src/components/QueryEditor.vue
+++ b/pgmanage/app/static/assets/js/pgmanage_frontend/src/components/QueryEditor.vue
@@ -11,7 +11,6 @@
 import ContextMenu from "@imengyu/vue3-context-menu";
 import { snippetsStore, settingsStore } from "../stores/stores_initializer";
 import { buildSnippetContextMenuObjects } from "../tree_context_functions/tree_snippets";
-import { uiCopyTextToClipboard } from "../workspace";
 import {
   autocomplete_start,
   autocomplete_keydown,
@@ -130,10 +129,9 @@ export default {
         {
           label: "Copy",
           icon: "fas cm-all fa-terminal",
+          disabled: !this.editor.getSelectedText(),
           onClick: () => {
-            let copy_text = this.getQueryEditorValue(true);
-
-            uiCopyTextToClipboard(copy_text);
+            document.execCommand("copy");
           },
         },
         {

--- a/pgmanage/app/static/assets/js/pgmanage_frontend/src/workspace.js
+++ b/pgmanage/app/static/assets/js/pgmanage_frontend/src/workspace.js
@@ -1213,23 +1213,6 @@ function monitoringAction(row_data, p_function) {
   }
 }
 
-function uiCopyTextToClipboard(p_value) {
-  // Create temporary invisible textarea.
-  var v_text_area = document.createElement('textarea');
-  v_text_area.styleList = {'height':'0px','overflow':'hidden'}
-  document.body.appendChild(v_text_area);
-  // Updating the temporary textarea and selecting the values.
-  v_text_area.value = p_value;
-  v_text_area.select();
-  v_text_area.setSelectionRange(0, 9999999);
-  // Copying the text inside the temporary textarea.
-  document.execCommand("copy");
-  // Remove and delete the temporary textarea.
-  document.body.removeChild(v_text_area);
-  v_text_area = null
-  // Prompting an alert.
-  showAlert('<b>Text copied:</b> \n<div class="mt-2 p-2 border-1 omnidb__theme-bg--light"><code>' + p_value + '</code></div>');
-}
 
 function toggleConnectionAutocomplete(toggler_id, conn_id) {
   let checked = document.getElementById(toggler_id).checked;
@@ -1262,5 +1245,4 @@ export {
   resizeSnippetHorizontal,
   toggleConnectionAutocomplete,
   toggleTreeContainer,
-  uiCopyTextToClipboard
 };


### PR DESCRIPTION
fix issue when editor context menu "copy" copies full sql windows instead of selected text #268 