### PR TITLE
allow using unix domain socket paths in connection form -> server field

### DIFF
--- a/pgmanage/app/include/Spartacus/Database.py
+++ b/pgmanage/app/include/Spartacus/Database.py
@@ -28,6 +28,7 @@ import datetime
 import decimal
 import json
 import math
+import re
 
 import app.include.Spartacus as Spartacus
 import app.include.Spartacus.prettytable as prettytable
@@ -1904,7 +1905,11 @@ MySQL
 class MySQL(Generic):
     def __init__(self, p_host, p_port, p_service, p_user, p_password, p_conn_string='', p_encoding=None, connection_params=None):
         if 'MySQL' in v_supported_rdbms:
-            self.v_host = p_host
+            if re.match(r'^\/$|(^(?=\/))(\/(?=[^/\0])[^/\0]+)*\/?$', p_host):
+                self.server_params = {'unix_socket': p_host}
+            else:
+                self.server_params = {'host': p_host}
+
             if p_port is None or p_port == '':
                 self.v_port = 3306
             else:
@@ -1964,7 +1969,6 @@ class MySQL(Generic):
     def Open(self, p_autocommit=True):
         try:
             self.v_con = pymysql.connect(
-                host=self.v_host,
                 port=int(self.v_port),
                 db=self.v_service,
                 user=self.v_user,
@@ -1972,7 +1976,8 @@ class MySQL(Generic):
                 autocommit=p_autocommit,
                 read_default_file='~/.my.cnf',
                 client_flag=CLIENT.MULTI_STATEMENTS,
-                **self.connection_params
+                **self.connection_params,
+                **self.server_params
                 )
             self.v_cur = self.v_con.cursor()
             self.v_start = True
@@ -2297,7 +2302,11 @@ MariaDB
 class MariaDB(Generic):
     def __init__(self, p_host, p_port, p_service, p_user, p_password, p_conn_string='', p_encoding=None, connection_params=None):
         if 'MariaDB' in v_supported_rdbms:
-            self.v_host = p_host
+            if re.match(r'^\/$|(^(?=\/))(\/(?=[^/\0])[^/\0]+)*\/?$', p_host):
+                self.server_params = {'unix_socket': p_host}
+            else:
+                self.server_params = {'host': p_host}
+
             if p_port is None or p_port == '':
                 self.v_port = 3306
             else:
@@ -2357,7 +2366,6 @@ class MariaDB(Generic):
     def Open(self, p_autocommit=True):
         try:
             self.v_con = pymysql.connect(
-                host=self.v_host,
                 port=int(self.v_port),
                 db=self.v_service,
                 user=self.v_user,
@@ -2366,6 +2374,7 @@ class MariaDB(Generic):
                 read_default_file='~/.my.cnf',
                 client_flag=CLIENT.MULTI_STATEMENTS,
                 **self.connection_params,
+                **self.server_params
                 )
             self.v_cur = self.v_con.cursor()
             self.v_start = True

--- a/pgmanage/app/static/assets/js/pgmanage_frontend/src/components/ConnectionsModalConnectionForm.vue
+++ b/pgmanage/app/static/assets/js/pgmanage_frontend/src/components/ConnectionsModalConnectionForm.vue
@@ -306,9 +306,11 @@ import { Modal } from 'bootstrap';
         // absolute paths without .. . and ~
         const pathre = /^\/$|(^(?=\/))(\/(?=[^/\0])[^/\0]+)*\/?$/
 
-        if(['postgresql', 'mariadb', 'mysql'].includes(this.connectionLocal.technology)) {
+        if(['mariadb', 'mysql'].includes(this.connectionLocal.technology)) {
+          return ipv4re.test(value) || ipv6re.test(value) || hostre.test(value) || pathre.test(value)
+        }else if (this.connectionLocal.technology === 'postgresql'){
           return ipv4re.test(value) || ipv6re.test(value) || hostre.test(value) || pathre.test(value) || !helpers.req(value)
-        }else {
+        } else {
           return ipv4re.test(value) || ipv6re.test(value) || hostre.test(value)
         }
       }

--- a/pgmanage/app/static/assets/js/pgmanage_frontend/src/components/ConnectionsModalConnectionForm.vue
+++ b/pgmanage/app/static/assets/js/pgmanage_frontend/src/components/ConnectionsModalConnectionForm.vue
@@ -299,12 +299,18 @@ import { Modal } from 'bootstrap';
       const needsServer = !['terminal', 'sqlite'].includes(this.connectionLocal.technology)
       const needsTunnel = this.connectionLocal.technology === 'terminal' || (this.connectionLocal.tunnel && this.connectionLocal.tunnel.enabled)
       const hostOrIp = function(value) {
-        const ipv4re = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/
         const hostre = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/
+        const ipv4re = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$/
         // yes, this one is pretty long and cannot be easily made multi-line without extra tricks
         const ipv6re = /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$/
+        // absolute paths without .. . and ~
+        const pathre = /^\/$|(^(?=\/))(\/(?=[^/\0])[^/\0]+)*\/?$/
 
-        return ipv4re.test(value) || ipv6re.test(value) || hostre.test(value)
+        if(['postgresql', 'mariadb', 'mysql'].includes(this.connectionLocal.technology)) {
+          return ipv4re.test(value) || ipv6re.test(value) || hostre.test(value) || pathre.test(value) || !helpers.req(value)
+        }else {
+          return ipv4re.test(value) || ipv6re.test(value) || hostre.test(value)
+        }
       }
 
       let baseRules = {
@@ -331,9 +337,15 @@ import { Modal } from 'bootstrap';
 
       if(needsServer) {
         if(!this.connectionLocal.conn_string) {
-          baseRules.connectionLocal.server = {
-            required,
-            hostOrIp: helpers.withMessage('Must be a valid hostname or IP', hostOrIp)
+          if(['postgresql', 'mariadb', 'mysql'].includes(this.connectionLocal.technology)){
+            baseRules.connectionLocal.server = {
+              hostOrIp: helpers.withMessage('Must be a valid hostname, IP or a UNIX socket base path', hostOrIp)
+            }
+          } else {
+            baseRules.connectionLocal.server = {
+              required,
+              hostOrIp: helpers.withMessage('Must be a valid hostname or IP', hostOrIp)
+            }
           }
 
           baseRules.connectionLocal.port = {


### PR DESCRIPTION
allow empty server valued in the connection form for postgres connections
add unix socket support for mariadb/mysql
refs: #437

test cases:
postgres connections should allow hostnames, IP addresses, empty values and absolute unix paths
mysql/mariadb connections should allow hostnames, IP addresses and absolute unix paths

postgres connections should look for sockets under default postgres socket path if server field is empty
postgres connections should look for sockets under the base path provided in the server field
mariadb/mysql connections should look for socket file specified by absolute socket path

other connection types: shoud work as before, file paths or empty values are not allowed
postgres/maridadb/mysql should work with ips and hostnames as before