### PR TITLE
Fall back to unencrypted ssh key when no password is provided

### DIFF
--- a/pgmanage/app/views/connections.py
+++ b/pgmanage/app/views/connections.py
@@ -225,7 +225,7 @@ def test_connection(request):
         try:
             # ssh key provided
             if ssh_key.strip() != '':
-                key = paramiko.RSAKey.from_private_key(io.StringIO(ssh_key), password=ssh_password)
+                key = paramiko.RSAKey.from_private_key(io.StringIO(ssh_key), password=ssh_password or None)
                 client.connect(hostname=conn_object['tunnel']['server'], username=conn_object['tunnel']['user'],
                                pkey=key, passphrase=ssh_password,
                                port=int(conn_object['tunnel']['port']), timeout=5)
@@ -260,7 +260,7 @@ def test_connection(request):
 
             try:
                 if ssh_key.strip() != '':
-                    key = paramiko.RSAKey.from_private_key(io.StringIO(ssh_key), password=ssh_password)
+                    key = paramiko.RSAKey.from_private_key(io.StringIO(ssh_key), password=ssh_password or None)
                     server = SSHTunnelForwarder(
                         (conn_object['tunnel']['server'], int(conn_object['tunnel']['port'])),
                         ssh_username=conn_object['tunnel']['user'],

--- a/pgmanage/app/views/polling.py
+++ b/pgmanage/app/views/polling.py
@@ -255,7 +255,7 @@ def create_request(request, session):
 
                     #ssh key provided
                     if v_conn_object['tunnel']['key'].strip() != '':
-                        key = paramiko.RSAKey.from_private_key(io.StringIO(v_conn_object['tunnel']['key']), password=v_conn_object['tunnel']['password'])
+                        key = paramiko.RSAKey.from_private_key(io.StringIO(v_conn_object['tunnel']['key']), password=v_conn_object['tunnel']['password'] or None)
                         client.connect(hostname=v_conn_object['tunnel']['server'],username=v_conn_object['tunnel']['user'],pkey=key,passphrase=v_conn_object['tunnel']['password'],port=int(v_conn_object['tunnel']['port']))
                     else:
                         client.connect(hostname=v_conn_object['tunnel']['server'],username=v_conn_object['tunnel']['user'],password=v_conn_object['tunnel']['password'],port=int(v_conn_object['tunnel']['port']))


### PR DESCRIPTION
Currently, when using a SSH tunnel, if the SSH key is not encrypted with a password (so the user leaves the passphrase field empty), trying to establish a tunnel will result in PgManage throwing an error (`password and salt must not be empty`).

This is because an empty string is passed to `from_private_key`.
This commit makes it so that when calling `from_private_key` if the password string is empty, it defaults to `None`, which is the expected value for unencrypted keys.