### PR TITLE
534 auto hide error messages 

### DIFF
--- a/pgmanage/app/static/pgmanage_frontend/src/notification_control.js
+++ b/pgmanage/app/static/pgmanage_frontend/src/notification_control.js
@@ -148,7 +148,7 @@ function showToast(type, message) {
   $toast.open({
     message: html_msg,
     type: type,
-    duration: type === 'error' ? 0 : 3000
+    duration: type === 'error' ? 30000 : 3000
   })
 }
 


### PR DESCRIPTION
sets duration of error toast to 30 seconds
refs: #534 