### PR TITLE
531 set backup type based on output file extension

### DIFF
--- a/pgmanage/app/file_manager/file_manager.py
+++ b/pgmanage/app/file_manager/file_manager.py
@@ -72,7 +72,8 @@ class FileManager:
 
             file_path = os.path.join(path, file)
             file_size = os.path.getsize(file_path)
-            file_type = "dir" if os.path.isdir(file_path) else "file"
+            is_directory = os.path.isdir(file_path)
+            file_type = self._get_file_extension(file)
             created = os.path.getctime(file_path)
             modified = os.path.getmtime(file_path)
             dir_size = None
@@ -82,9 +83,10 @@ class FileManager:
             data["files"].append(
                 {
                     "file_name": file,
-                    "file_path": file_path,
+                    "path": file_path,
                     "file_size": self._format_size(file_size),
-                    "file_type": file_type,
+                    "is_directory": is_directory,
+                    "type": file_type,
                     "created": time.ctime(created),
                     "modified": time.ctime(modified),
                     "dir_size": dir_size,
@@ -135,3 +137,7 @@ class FileManager:
             pathlib.Path(abs_path).relative_to(self.storage)
         except ValueError:
             raise PermissionError(f"Access denied: {abs_path}")
+
+    def _get_file_extension(self, file_name: str) -> str:
+        _, extension = os.path.splitext(file_name)
+        return extension.lstrip(".").lower() if extension else ""

--- a/pgmanage/app/static/pgmanage_frontend/src/components/FileManager.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/FileManager.vue
@@ -128,8 +128,8 @@
                 ]"
                 @click="selectFileOrDir(file.file_name)"
                 @dblclick="
-                  file.file_type === 'dir'
-                    ? getDirContent(file.file_path)
+                  file.is_directory
+                    ? getDirContent(file.path)
                     : confirmSelection()
                 "
               >
@@ -140,13 +140,13 @@
                       'fa-2xl',
                       'me-2',
                       {
-                        'fa-folder': file.file_type === 'dir',
-                        'fa-file': file.file_type === 'file',
+                        'fa-folder': file.is_directory,
+                        'fa-file': !file.is_directory,
                       },
                     ]"
                     :style="{
                       color:
-                        file.file_type === 'dir'
+                        file.is_directory
                           ? '#0ea5e9'
                           : 'rgb(105 114 118)',
                     }"
@@ -173,8 +173,8 @@
                     :key="file.file_name"
                     @click="selectFileOrDir(file.file_name)"
                     @dblclick="
-                      file.file_type === 'dir'
-                        ? getDirContent(file.file_path)
+                      file.is_directory
+                        ? getDirContent(file.path)
                         : confirmSelection()
                     "
                   >
@@ -184,23 +184,23 @@
                           'fas',
                           'fa-2xl',
                           {
-                            'fa-folder': file.file_type === 'dir',
-                            'fa-file': file.file_type === 'file',
+                            'fa-folder': file.is_directory,
+                            'fa-file': !file.is_directory,
                           },
                         ]"
                         :style="{
                           color:
-                            file.file_type === 'dir'
+                            file.is_directory
                               ? '#0ea5e9'
                               : 'rgb(105 114 118)',
                         }"
                       ></i>
                       {{ file.file_name }}
                     </div>
-                    <div class="col-2" v-if="file.file_type === 'file'">
+                    <div class="col-2" v-if="!file.is_directory">
                       {{ file.file_size }}
                     </div>
-                    <div class="col-2" v-if="file.file_type === 'dir'">
+                    <div class="col-2" v-if="file.is_directory">
                       {{ file.dir_size }}
                       {{ file.dir_size == 1 ? "item" : "items" }}
                     </div>
@@ -329,7 +329,7 @@ export default {
       Modal.getOrCreateInstance(this.$refs.actionsModal.$el).show();
     },
     confirmSelection() {
-      fileManagerStore.changeFile(this.selectedFile.file_path);
+      fileManagerStore.changeFile(this.selectedFile);
       Modal.getOrCreateInstance(this.$refs.fileManagerModal).hide();
     },
     show(desktopMode, onChange, dialog_type) {

--- a/pgmanage/app/static/pgmanage_frontend/src/stores/file_manager.js
+++ b/pgmanage/app/static/pgmanage_frontend/src/stores/file_manager.js
@@ -4,7 +4,7 @@ const useFileManagerStore = defineStore("fileManager", {
   state: () => ({
     onChange: () => {},
     dialogType: null,
-    filePath: null,
+    file: null,
     visible: false,
     desktopMode: null,
   }),
@@ -15,8 +15,8 @@ const useFileManagerStore = defineStore("fileManager", {
       this.onChange = onChange;
       this.dialogType = dialogType;
     },
-    changeFile(filePath) {
-      this.filePath = filePath;
+    changeFile(file) {
+      this.file = file;
     },
     hideModal() {
       this.visible = false;


### PR DESCRIPTION
sets backup type based on output file extension and vice-versa refs: #531

adds is_directory attribute to file in file_manager.py changes file_type to type and adds proper method for getting file extesion changeFile method in file_manager store now changes file instead of file path