### PR TITLE
Wrong "discard changes" warning fix

### DIFF
--- a/pgmanage/app/static/pgmanage_frontend/src/components/QueryTab.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/QueryTab.vue
@@ -297,7 +297,7 @@ export default {
           this.showFetchButtons = false;
           this.longQuery = false;
           this.tempData = [];
-          this.lastQuery = query
+          this.lastQuery = query.trim();
 
           let message_data = {
             sql_cmd: query,


### PR DESCRIPTION
fixes issue with false positive "discard changes" warning.
The problem was  with query editor value.
The `@editor-change` event  from `QueryEditor` component returns a trimmed editor value, which is stored as `this.editorContent`.
When running a query , the last executed query ( `this.lastQuery `) is stored without trimming, directly from the editor's raw value.