### PR TITLE
temporary workaround for DROP DATABASE issue with currently used DB

### DIFF
--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreePostgresql.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreePostgresql.vue
@@ -112,8 +112,10 @@ export default {
             label: "Query Database",
             icon: "fas cm-all fa-search",
             onClick: () => {
-              let tab_name = `Query: ${tabsStore.selectedPrimaryTab.metaData.selectedDatabase}`
-              tabsStore.createQueryTab(tab_name)
+              this.checkCurrentDatabase(this.selectedNode, true, () => {
+                let tab_name = `Query: ${tabsStore.selectedPrimaryTab.metaData.selectedDatabase}`;
+                tabsStore.createQueryTab(tab_name);
+              });
             }
           },
           {
@@ -2778,15 +2780,13 @@ export default {
       this.$refs.tree.select(node.path);
       e.preventDefault();
       if (!!node.data.contextMenu) {
-        this.checkCurrentDatabase(node, true, () => {
-          ContextMenu.showContextMenu({
+        ContextMenu.showContextMenu({
             theme: "pgmanage",
             x: e.x,
             y: e.y,
             zIndex: 1000,
             minWidth: 230,
             items: this.contextMenu[node.data.contextMenu],
-          });
         });
       }
     },

--- a/pgmanage/app/utils/decorators.py
+++ b/pgmanage/app/utils/decorators.py
@@ -17,13 +17,19 @@ def user_authenticated(function):
     return wrap
 
 
-def database_required(check_timeout=True, open_connection=True):
+def database_required(check_timeout=True, open_connection=True, prefer_database=None):
     def decorator(function):
         @session_required
         @wraps(function)
         def wrap(request, session, *args, **kwargs):
             data = request.data
-            database_name = data.get("database_name")
+            # FIXME: prefer_database is a temporary workaround to prevent
+            # issues with DROP DATABASE caused by opening DB backends to
+            # currently selected database when DB tree is loaded
+            if prefer_database is not None:
+                database_name = prefer_database
+            else:
+                database_name = data.get("database_name")
             database_index = data.get("database_index")
             tab_id = data.get("tab_id")
             workspace_id=data.get("workspace_id")

--- a/pgmanage/app/views/tree_postgresql.py
+++ b/pgmanage/app/views/tree_postgresql.py
@@ -5,7 +5,7 @@ from app.utils.decorators import database_required, user_authenticated
 from django.http import HttpResponse, JsonResponse
 
 @user_authenticated
-@database_required(check_timeout=True, open_connection=True)
+@database_required(check_timeout=True, open_connection=False, prefer_database='template1')
 def get_tree_info(request, database):
     try:
         data = {
@@ -808,7 +808,7 @@ def get_schemas(request, database):
 
 
 @user_authenticated
-@database_required(check_timeout=True, open_connection=True)
+@database_required(check_timeout=True, open_connection=False, prefer_database='template1')
 def get_databases(request, database):
     list_databases = []
 

--- a/pgmanage/app/views/tree_postgresql.py
+++ b/pgmanage/app/views/tree_postgresql.py
@@ -5,7 +5,7 @@ from app.utils.decorators import database_required, user_authenticated
 from django.http import HttpResponse, JsonResponse
 
 @user_authenticated
-@database_required(check_timeout=True, open_connection=False, prefer_database='template1')
+@database_required(check_timeout=True, open_connection=False, prefer_database='template0')
 def get_tree_info(request, database):
     try:
         data = {
@@ -808,7 +808,7 @@ def get_schemas(request, database):
 
 
 @user_authenticated
-@database_required(check_timeout=True, open_connection=False, prefer_database='template1')
+@database_required(check_timeout=True, open_connection=False, prefer_database='template0')
 def get_databases(request, database):
     list_databases = []
 


### PR DESCRIPTION
1: do not change the active database when righ-clicking DB tree node 2: run get_tree_info and get_databases against template1 db when
   loadingb DB object tree -> prevents actual DBs from getting "used"

refs: #581