### PR TITLE
Power tree computed fix

### DIFF
--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreeMariaDB.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreeMariaDB.vue
@@ -67,12 +67,13 @@ export default {
         },
       ],
       templates: "",
+      cm_server_extra: [],
     };
   },
   computed: {
     contextMenu() {
       return {
-        cm_server: [this.cmRefreshObject],
+        cm_server: [this.cmRefreshObject, ...this.cm_server_extra],
         cm_databases: [
           this.cmRefreshObject,
           {
@@ -835,8 +836,7 @@ export default {
             type: "database_list",
             contextMenu: "cm_databases",
           });
-          this.contextMenu.cm_server = [this.cmRefreshObject];
-          this.contextMenu.cm_server.push({
+          this.cm_server_extra = [{
             label: "Monitoring",
             icon: "fas fa-chart-line",
             children: [
@@ -848,7 +848,7 @@ export default {
                 },
               },
             ],
-          });
+          }];
         })
         .catch((error) => {
           this.nodeOpenError(error, node);

--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreeMysql.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreeMysql.vue
@@ -68,12 +68,13 @@ export default {
         },
       ],
       templates: "",
+      cm_server_extra: [],
     };
   },
   computed: {
     contextMenu() {
       return {
-        cm_server: [this.cmRefreshObject],
+        cm_server: [this.cmRefreshObject, ...this.cm_server_extra],
         cm_databases: [
           this.cmRefreshObject,
           {
@@ -783,8 +784,7 @@ export default {
             type: "database_list",
             contextMenu: "cm_databases",
           });
-          this.contextMenu.cm_server = [this.cmRefreshObject];
-          this.contextMenu.cm_server.push({
+          this.cm_server_extra = [{
             label: "Monitoring",
             icon: "fas fa-chart-line",
             children: [
@@ -796,7 +796,7 @@ export default {
                 },
               },
             ],
-          });
+          }];
         })
         .catch((error) => {
           this.nodeOpenError(error, node);

--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreeOracle.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreeOracle.vue
@@ -60,12 +60,13 @@ export default {
         },
       ],
       templates: "",
+      cm_server_extra: [],
     };
   },
   computed: {
     contextMenu() {
       return {
-        cm_server: [this.cmRefreshObject],
+        cm_server: [this.cmRefreshObject, ...this.cm_server_extra],
         cm_database: [
           {
             label: "ER Diagram",
@@ -757,8 +758,7 @@ export default {
           this.templates = resp.data;
 
           if (resp.data.superuser) {
-            this.contextMenu.cm_server = [this.cmRefreshObject];
-            this.contextMenu.cm_server.push({
+            this.cm_server_extra = [{
               label: "Monitoring",
               icon: "fas fa-chart-line",
               children: [
@@ -770,7 +770,7 @@ export default {
                   },
                 },
               ],
-            });
+            }];
 
             this.insertNode(node, "Roles", {
               icon: "fas node-all fa-users node-user-list",

--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreePostgresql.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreePostgresql.vue
@@ -71,6 +71,7 @@ export default {
         },
       ],
       currentSchema: "public",
+      cm_server_extra: [],
     };
   },
   computed: {
@@ -84,7 +85,7 @@ export default {
       };
 
       return {
-        cm_server: [this.cmRefreshObject],
+        cm_server: [this.cmRefreshObject, ...this.cm_server_extra],
         cm_databases: [
           this.cmRefreshObject,
           {
@@ -3097,10 +3098,8 @@ export default {
         const response = await this.api.post("/get_tree_info_postgresql/")
 
         this.removeChildNodes(node);
-  
-        this.contextMenu.cm_server = [this.cmRefreshObject];
-        this.contextMenu.cm_server.push(
-          {
+        
+        this.cm_server_extra = [{
             label: "Server Configuration",
             icon: "fas fa-cog",
             onClick: () => {
@@ -3186,8 +3185,7 @@ export default {
                 )}/sql-commands.html`
               );
             },
-          }
-        );
+          }];
   
         this.templates = response.data;
   


### PR DESCRIPTION
 fixes issue with directly mutating computed property
 
 after updating vue from 3.5.4 to 3.5.13 directly updating computed property stopped working
 The reason it was working before is probably a bug that has now been fixed.