### PR TITLE
251 foreign key support in schema editor

### DIFF
--- a/pgmanage/app/include/OmniDatabase/MySQL.py
+++ b/pgmanage/app/include/OmniDatabase/MySQL.py
@@ -331,6 +331,8 @@ class MySQL:
             select distinct i.constraint_name as "constraint_name",
                    i.table_name as "table_name",
                    k.referenced_table_name as "r_table_name",
+                   k.column_name as "column_name",
+                   k.referenced_column_name as "r_column_name",
                    k.table_schema as "table_schema",
                    k.referenced_table_schema as "r_table_schema",
                    r.update_rule as "update_rule",

--- a/pgmanage/app/include/OmniDatabase/PostgreSQL.py
+++ b/pgmanage/app/include/OmniDatabase/PostgreSQL.py
@@ -787,14 +787,14 @@ class PostgreSQL:
             INNER JOIN pg_namespace rtn
                     ON rt.relnamespace = rtn.oid
                     
-            -- Local column names (composite key support)
+            -- Local column names
             LEFT JOIN LATERAL (
                 SELECT string_agg(quote_ident(att.attname), ', ') AS local_columns
                 FROM unnest(c.conkey) WITH ORDINALITY AS cols(attnum, ord)
                 JOIN pg_attribute att ON att.attrelid = c.conrelid AND att.attnum = cols.attnum
             ) AS lc ON true
 
-            -- Foreign column names (composite key support)
+            -- Foreign column names
             LEFT JOIN LATERAL (
                 SELECT string_agg(quote_ident(att.attname), ', ') AS foreign_columns
                 FROM unnest(c.confkey) WITH ORDINALITY AS cols(attnum, ord)

--- a/pgmanage/app/include/OmniDatabase/PostgreSQL.py
+++ b/pgmanage/app/include/OmniDatabase/PostgreSQL.py
@@ -710,13 +710,17 @@ class PostgreSQL:
                             quote_ident(rtn.nspname) AS r_table_schema,
                             c.update_rule,
                             c.delete_rule,
-                            c.oid
+                            c.oid,
+                            lc.local_columns as column_name,
+                            fc.foreign_columns as r_column_name      
             FROM (
                 SELECT oid,
                        connamespace,
                        conname,
                        conrelid,
                        confrelid,
+                       conkey,
+                       confkey,
                        (CASE confupdtype WHEN 'c'
                                          THEN 'CASCADE'
                                          WHEN 'n'
@@ -782,6 +786,21 @@ class PostgreSQL:
                     ON rc.conrelid = rt.oid
             INNER JOIN pg_namespace rtn
                     ON rt.relnamespace = rtn.oid
+                    
+            -- Local column names (composite key support)
+            LEFT JOIN LATERAL (
+                SELECT string_agg(quote_ident(att.attname), ', ') AS local_columns
+                FROM unnest(c.conkey) WITH ORDINALITY AS cols(attnum, ord)
+                JOIN pg_attribute att ON att.attrelid = c.conrelid AND att.attnum = cols.attnum
+            ) AS lc ON true
+
+            -- Foreign column names (composite key support)
+            LEFT JOIN LATERAL (
+                SELECT string_agg(quote_ident(att.attname), ', ') AS foreign_columns
+                FROM unnest(c.confkey) WITH ORDINALITY AS cols(attnum, ord)
+                JOIN pg_attribute att ON att.attrelid = c.confrelid AND att.attnum = cols.attnum
+            ) AS fc ON true
+
             WHERE 1 = 1
             {0}
             ORDER BY quote_ident(c.conname),

--- a/pgmanage/app/static/pgmanage_frontend/src/components/SchemaEditorConstraintsList.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/SchemaEditorConstraintsList.vue
@@ -1,0 +1,216 @@
+<template>
+  <div class="mb-2">
+    <div class="d-flex row fw-bold text-muted schema-editor__header g-0">
+      <div class="col">
+        <p class="h6">Name</p>
+      </div>
+      <div class="col-1">
+        <p class="h6">Column Name</p>
+      </div>
+      <div class="col-1">
+        <p class="h6">FK Schema</p>
+      </div>
+      <div class="col-1">
+        <p class="h6">FK Table</p>
+      </div>
+      <div class="col-2">
+        <p class="h6">FK Column</p>
+      </div>
+      <div class="col-1">
+        <p class="h6">On Update</p>
+      </div>
+      <div class="col-1">
+        <p class="h6">On Delete</p>
+      </div>
+      <div class="col-1">
+        <p class="h6">Actions</p>
+      </div>
+    </div>
+    <div
+      v-for="(constraint, idx) in constraints"
+      :key="idx"
+      :class="[
+        'schema-editor__column d-flex row flex-nowrap form-group g-0',
+        { 'schema-editor__column-deleted': constraint.deleted },
+        { 'schema-editor__column-new': constraint.new },
+        { 'schema-editor__column-dirty': constraint.is_dirty },
+      ]"
+    >
+      <div class="col d-flex align-items-center">
+        <input
+          type="text"
+          v-model="constraint.constraint_name"
+          class="form-control mb-0 ps-2"
+          placeholder="constraint name..."
+          :disabled="!constraint.new"
+        />
+      </div>
+
+      <div class="col-1 d-flex align-items-center">
+        <input
+          type="text"
+          v-model="constraint.column_name"
+          class="form-control mb-0 ps-2"
+          placeholder="column name..."
+          :disabled="!constraint.new"
+        />
+      </div>
+
+      <div class="col-1 d-flex align-items-center">
+        <SearchableDropdown
+          placeholder="foreign key table schema.."
+          :options="tables"
+          v-model="constraint.r_table_schema"
+          :disabled="!constraint.new"
+        />
+      </div>
+
+      <div class="col-1 d-flex align-items-center">
+        <SearchableDropdown
+          placeholder="foreign key table.."
+          :options="tables"
+          v-model="constraint.r_table_name"
+          :disabled="!constraint.new"
+        />
+      </div>
+
+      <div class="col-2 d-flex align-items-center">
+        <SearchableDropdown
+          placeholder="foreign key column.."
+          :options="columns"
+          v-model="constraint.r_column_name"
+          :disabled="!constraint.new"
+        />
+      </div>
+
+      <div class="col-1">
+        <SearchableDropdown
+          placeholder="foreign key table.."
+          :options="constraintActions"
+          v-model="constraint.on_update"
+          :disabled="!constraint.new"
+        />
+      </div>
+
+      <div class="col-1 d-flex align-items-center">
+        <SearchableDropdown
+          placeholder="foreign key table.."
+          :options="constraintActions"
+          v-model="constraint.on_delete"
+          :disabled="!constraint.new"
+        />
+      </div>
+
+      <div class="col-1 d-flex me-2 justify-content-end">
+        <button
+          v-if="(constraint.deleted && !constraint.new) || constraint.is_dirty"
+          @click="revertConstraint(idx)"
+          type="button"
+          class="btn btn-icon btn-icon-success"
+          title="Revert"
+        >
+          <i class="fas fa-rotate-left"></i>
+        </button>
+
+        <button
+          v-if="!constraint.deleted && !constraint.is_dirty"
+          @click="removeConstraint(idx)"
+          type="button"
+          class="btn btn-icon btn-icon-danger"
+          title="Remove constraint"
+        >
+          <i class="fas fa-circle-xmark"></i>
+        </button>
+      </div>
+    </div>
+    <div class="d-flex g-0 fw-bold mt-2">
+      <button @click="addConstraint" class="btn btn-outline-success ms-auto">
+        Add Constraint
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+import SearchableDropdown from "./SearchableDropdown.vue";
+
+export default {
+  name: "SchemaEditorConstraintsList",
+  components: {
+    SearchableDropdown,
+  },
+  props: {
+    initialConstraints: {
+      type: Array,
+      default: [],
+    },
+    disabledFeatures: {
+      type: Object,
+      default: {},
+    },
+    columns: Array,
+  },
+  emits: ["constraints:changed"],
+  data() {
+    return {
+      constraints: [],
+      constraintActions: [
+        "NO ACTION",
+        "SET NULL",
+        "SET DEFAULT",
+        "CASCADE",
+        "RESTRICT",
+      ],
+      tables: [],
+    };
+  },
+  methods: {
+    addConstraint() {
+      let constraintName = `fk_${this.constraints.length}`;
+      const defaultConstraint = {
+        name: constraintName,
+        fk_column: null,
+        new: true,
+        editable: true,
+        on_update: "NO ACTION",
+        on_delete: "NO ACTION",
+        is_dirty: false,
+      };
+      this.constraints.push(defaultConstraint);
+    },
+    removeConstraint(index) {
+      if (!this.constraints[index].new) {
+        this.constraints[index].deleted = true;
+      } else {
+        this.constraints.splice(index, 1);
+      }
+    },
+    revertConstraint(index) {
+      this.constraints[index] = JSON.parse(
+        JSON.stringify(this.initialConstraints[index])
+      );
+    },
+  },
+  watch: {
+    initialConstraints: {
+      handler(newVal, oldVal) {
+        this.constraints = JSON.parse(JSON.stringify(newVal));
+      },
+      immediate: true,
+    },
+    constraints: {
+      handler(newVal, oldVal) {
+        this.$emit("constraints:changed", newVal);
+      },
+      deep: true,
+    },
+  },
+};
+</script>
+
+<style scoped>
+input[type="checkbox"].custom-checkbox:disabled {
+  background-color: initial;
+  border-color: rgba(118, 118, 118, 0.3);
+}
+</style>

--- a/pgmanage/app/static/pgmanage_frontend/src/components/SchemaEditorConstraintsList.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/SchemaEditorConstraintsList.vue
@@ -205,20 +205,29 @@ export default {
       );
     },
     getTables(r_table_schema) {
-      let schema = this.dbMetaData.find(
-        (schema) => schema.name === r_table_schema
-      );
-      if (!schema) return;
+      let schema;
+      if (this.hasSchema) {
+        schema = this.dbMetaData.find(
+          (schema) => schema.name === r_table_schema
+        );
+        if (!schema) return;
+      } else {
+        schema = this.dbMetaData[0] ?? null;
+      }
       return schema?.tables.map((table) => table.name) ?? [];
     },
     getColumns(r_table_schema, r_table_name) {
-      let schema = this.dbMetaData.find(
-        (schema) => schema.name === r_table_schema
-      );
-      if (!schema) return;
+      let schema;
+      if (this.hasSchema) {
+        schema = this.dbMetaData.find(
+          (schema) => schema.name === r_table_schema
+        );
+        if (!schema) return;
+      } else {
+        schema = this.dbMetaData[0] ?? null;
+      }
 
       let table = schema?.tables.find((table) => table.name === r_table_name);
-
       if (!table) return;
 
       return table.columns ?? [];

--- a/pgmanage/app/static/pgmanage_frontend/src/components/SchemaEditorConstraintsList.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/SchemaEditorConstraintsList.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="mb-2">
     <div class="d-flex row fw-bold text-muted schema-editor__header g-0">
-      <div class="col-2">
+      <div class="col">
         <p class="h6">Name</p>
       </div>
-      <div class="col-1">
+      <div class="col-2">
         <p class="h6">Column Name</p>
       </div>
-      <div class="col-2">
+      <div v-if="hasSchema" class="col-1">
         <p class="h6">FK Schema</p>
       </div>
       <div class="col-2">
@@ -22,7 +22,7 @@
       <div class="col-1">
         <p class="h6">On Delete</p>
       </div>
-      <div class="col-1">
+      <div v-if="!disabledFeatures.dropConstraint" class="col-1">
         <p class="h6">Actions</p>
       </div>
     </div>
@@ -36,7 +36,7 @@
         { 'schema-editor__column-dirty': constraint.is_dirty },
       ]"
     >
-      <div class="col-2 d-flex align-items-center">
+      <div class="col d-flex align-items-center">
         <input
           type="text"
           v-model="constraint.constraint_name"
@@ -46,7 +46,7 @@
         />
       </div>
 
-      <div class="col-1 d-flex align-items-center">
+      <div class="col-2 d-flex align-items-center">
         <SearchableDropdown
           placeholder="column name..."
           :options="columns"
@@ -55,7 +55,7 @@
         />
       </div>
 
-      <div class="col-2 d-flex align-items-center">
+      <div v-if="hasSchema" class="col-1 d-flex align-items-center">
         <SearchableDropdown
           placeholder="foreign key table schema.."
           :options="schemas"
@@ -104,7 +104,10 @@
         />
       </div>
 
-      <div class="col-1 d-flex me-2 justify-content-end">
+      <div
+        v-if="!disabledFeatures.dropConstraint"
+        class="col-1 d-flex me-2 justify-content-end"
+      >
         <button
           v-if="(constraint.deleted && !constraint.new) || constraint.is_dirty"
           @click="revertConstraint(idx)"
@@ -126,7 +129,7 @@
         </button>
       </div>
     </div>
-    <div class="d-flex g-0 fw-bold mt-2">
+    <div v-if="!disabledFeatures.addConstraint" class="d-flex g-0 fw-bold mt-2">
       <button @click="addConstraint" class="btn btn-outline-success ms-auto">
         Add Constraint
       </button>
@@ -153,6 +156,10 @@ export default {
     },
     columns: Array,
     dbMetaData: Array,
+    hasSchema: {
+      type: Boolean,
+      default: true,
+    },
   },
   emits: ["constraints:changed"],
   data() {
@@ -245,10 +252,3 @@ export default {
   },
 };
 </script>
-
-<style scoped>
-input[type="checkbox"].custom-checkbox:disabled {
-  background-color: initial;
-  border-color: rgba(118, 118, 118, 0.3);
-}
-</style>

--- a/pgmanage/app/static/pgmanage_frontend/src/components/SchemaEditorTab.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/SchemaEditorTab.vue
@@ -63,6 +63,7 @@
           <ConstraintsList
           :initialConstraints="initialConstraints"
           :columns="columnNames"
+          :db-meta-data="dbMetadata"
           :disabled-features="disabledFeatures"
           @constraints:changed="changeConstraints"
           />
@@ -131,7 +132,7 @@ import { createRequest } from '../long_polling'
 import { queryRequestCodes, operationModes } from '../constants'
 import axios from 'axios'
 import { showToast } from '../notification_control'
-import { tabsStore } from '../stores/stores_initializer'
+import { dbMetadataStore, tabsStore } from '../stores/stores_initializer'
 import IndexesList from './SchemaEditorIndexesList.vue'
 import ConstraintsList from './SchemaEditorConstraintsList.vue'
 import isEqual from 'lodash/isEqual';
@@ -652,6 +653,9 @@ export default {
     },
     disabledFeatures() {
       return this.dialectData?.disabledFeatures
+    },
+    dbMetadata() {
+      return dbMetadataStore.getDbMeta(this.databaseIndex, this.databaseName)
     }
   },
   watch: {

--- a/pgmanage/app/static/pgmanage_frontend/src/components/SchemaEditorTab.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/SchemaEditorTab.vue
@@ -411,15 +411,6 @@ export default {
           if(constraint.deleted) constraintChanges.drops.push(originalConstraints[idx].constraint_name)
           if(constraint.new) constraintChanges.adds.push(constraint)
           if(constraint.deleted || constraint.new) return
-
-          // if (!isEqual(index, originalIndexes[idx])) {
-          //   index.is_dirty = true;
-          //   originalIndexes[idx].is_dirty = true;
-          // } else {
-          //   index.is_dirty = false;
-          //   originalIndexes[idx].is_dirty = false;
-          // }
-          // if(index.index_name !== originalIndexes[idx].index_name) indexChanges.renames.push({'oldName': originalIndexes[idx].index_name, 'newName': index.index_name})
         })
 
         // we use initial table name here since localTable.tableName may be changed

--- a/pgmanage/app/static/pgmanage_frontend/src/components/SchemaEditorTab.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/SchemaEditorTab.vue
@@ -510,7 +510,7 @@ export default {
             const foreignSchema = constraintDef.r_table_schema;
             const constraintName = constraintDef.constraint_name;
 
-            if (!every([localColumn, foreignColumn, foreignTable, foreignSchema, constraintName])) return
+            if (!every([localColumn, foreignColumn, foreignTable, constraintName])) return
             const qualifiedForeignTable = foreignSchema
               ? `${foreignSchema}.${foreignTable}`
               : foreignTable;

--- a/pgmanage/app/static/pgmanage_frontend/src/components/SchemaEditorTab.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/SchemaEditorTab.vue
@@ -30,7 +30,7 @@
             Indexes
           </button>
         </li>
-        <li ref="constraintsTab" class="nav-item" role="presentation">
+        <li v-if="!disabledFeatures?.constraints" ref="constraintsTab" class="nav-item" role="presentation">
           <button class="nav-item nav-link" :id="`${tabId}-constraints-tab`"
             data-bs-toggle="tab"
             :data-bs-target="`#${tabId}-constraints-tab-pane`"
@@ -65,6 +65,7 @@
           :columns="columnNames"
           :db-meta-data="dbMetadata"
           :disabled-features="disabledFeatures"
+          :has-schema="dialect === 'postgres'"
           @constraints:changed="changeConstraints"
           />
         </div>

--- a/pgmanage/app/static/pgmanage_frontend/src/components/SearchableDropdown.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/SearchableDropdown.vue
@@ -77,7 +77,7 @@
         default: false
       }
     },
-    emits: ['update:modelValue'],
+    emits: ['update:modelValue', 'change'],
     data() {
       return {
         selected: this.multiSelect ? [] : null,
@@ -123,6 +123,7 @@
           this.optionsShown = false;
           this.searchFilter = this.selected;
         }
+        this.$emit('change', this.selected);
         this.highlightedIndex = -1;
       },
       showOptions(){

--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreeMysql.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreeMysql.vue
@@ -1115,7 +1115,7 @@ export default {
           });
 
           resp.data.reduceRight((_, el) => {
-            this.insertNode(node, el, {
+            this.insertNode(node, el.constraint_name , {
               icon: "fas node-all fa-key node-fkey",
               type: "foreign_key",
               contextMenu: "cm_fk",

--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreeSqlite.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreeSqlite.vue
@@ -609,7 +609,7 @@ export default {
             title: `Foreign Keys (${resp.data.length})`,
           });
           resp.data.reduceRight((_, el) => {
-            this.insertNode(node, el, {
+            this.insertNode(node, el.constraint_name, {
               icon: "fas node-all fa-key node-fkey",
               type: "foreign_key",
               contextMenu: "cm_fk",

--- a/pgmanage/app/static/pgmanage_frontend/src/components/dialect-data.js
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/dialect-data.js
@@ -6,7 +6,6 @@ import identity from 'lodash/identity';
 import flatten from 'lodash/flatten';
 
 // TODO: Mysql - add PrimaryKey and Comment handling in alter table
-// add constraints support for Mysql/Mariadb
 
 knex.TableBuilder.extend(
   "renameIndex",
@@ -100,12 +99,12 @@ export default Object.freeze({
         api_endpoints: {
           table_definition_url: "/get_table_definition_mysql/",
           indexes_url: "/get_indexes_mysql/",
+          constraints_url: "/get_fks_mysql/",
         },
         disabledFeatures: {
           indexPredicate: true,
           indexMethod: true,
           renameIndex: true,
-          constraints: true
       },
         overrides: [
           () => {

--- a/pgmanage/app/static/pgmanage_frontend/src/components/dialect-data.js
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/dialect-data.js
@@ -33,7 +33,7 @@ export default Object.freeze({
             types_url: "/get_types_postgresql/",
             indexes_url: "/get_indexes_postgresql/",
             table_definition_url: "/get_table_definition_postgresql/",
-            constraints_url: "/get_fks_postgresql/",
+            foreign_keys_url: "/get_fks_postgresql/",
         },
         overrides: [
             () => {
@@ -58,7 +58,7 @@ export default Object.freeze({
         api_endpoints: {
             table_definition_url: "/get_table_definition_sqlite/",
             indexes_url: "/get_indexes_sqlite/",
-            constraints_url: "/get_fks_sqlite/",
+            foreign_keys_url: "/get_fks_sqlite/",
         },
         disabledFeatures: {
             alterColumn: true,
@@ -66,8 +66,8 @@ export default Object.freeze({
             multiPrimaryKeys: true,
             renameIndex: true,
             indexMethod: true,
-            addConstraint: true,
-            dropConstraint: true,
+            addForeignKey: true,
+            dropForeignKey: true,
         },
         overrides: [
             () => {
@@ -99,7 +99,7 @@ export default Object.freeze({
         api_endpoints: {
           table_definition_url: "/get_table_definition_mysql/",
           indexes_url: "/get_indexes_mysql/",
-          constraints_url: "/get_fks_mysql/",
+          foreign_keys_url: "/get_fks_mysql/",
         },
         disabledFeatures: {
           indexPredicate: true,

--- a/pgmanage/app/static/pgmanage_frontend/src/components/dialect-data.js
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/dialect-data.js
@@ -32,7 +32,8 @@ export default Object.freeze({
             schemas_url: "/get_schemas_postgresql/",
             types_url: "/get_types_postgresql/",
             indexes_url: "/get_indexes_postgresql/",
-            table_definition_url: "/get_table_definition_postgresql/"
+            table_definition_url: "/get_table_definition_postgresql/",
+            constraints_url: "/get_fks_postgresql/",
         },
         overrides: [
             () => {

--- a/pgmanage/app/static/pgmanage_frontend/src/components/dialect-data.js
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/dialect-data.js
@@ -6,6 +6,7 @@ import identity from 'lodash/identity';
 import flatten from 'lodash/flatten';
 
 // TODO: Mysql - add PrimaryKey and Comment handling in alter table
+// add constraints support for Mysql/Mariadb
 
 knex.TableBuilder.extend(
   "renameIndex",
@@ -58,13 +59,16 @@ export default Object.freeze({
         api_endpoints: {
             table_definition_url: "/get_table_definition_sqlite/",
             indexes_url: "/get_indexes_sqlite/",
+            constraints_url: "/get_fks_sqlite/",
         },
         disabledFeatures: {
             alterColumn: true,
             multiStatement: true,
             multiPrimaryKeys: true,
             renameIndex: true,
-            indexMethod: true
+            indexMethod: true,
+            addConstraint: true,
+            dropConstraint: true,
         },
         overrides: [
             () => {
@@ -100,7 +104,8 @@ export default Object.freeze({
         disabledFeatures: {
           indexPredicate: true,
           indexMethod: true,
-          renameIndex: true
+          renameIndex: true,
+          constraints: true
       },
         overrides: [
           () => {

--- a/pgmanage/app/views/tree_mysql.py
+++ b/pgmanage/app/views/tree_mysql.py
@@ -169,9 +169,23 @@ def get_fks(request, database):
     table = data["table"]
     schema = data["schema"]
 
+    list_fk = []
+
     try:
         fks = database.QueryTablesForeignKeys(table, False, schema)
-        list_fk = [fk["constraint_name"] for fk in fks.Rows]
+        for fk in fks.Rows:
+            fk_data = {
+                "constraint_name": fk["constraint_name"],
+                "column_name": fk["column_name"],
+                "table_name": fk["table_name"],
+                "table_schema": fk["table_schema"],
+                "r_table_name": fk["r_table_name"],
+                "r_table_schema": fk["r_table_schema"],
+                "r_column_name": fk["r_column_name"],
+                "on_update": fk["update_rule"],
+                "on_delete": fk["delete_rule"],
+            }
+            list_fk.append(fk_data)
     except Exception as exc:
         return JsonResponse(data={"data": str(exc)}, status=400)
 

--- a/pgmanage/app/views/tree_postgresql.py
+++ b/pgmanage/app/views/tree_postgresql.py
@@ -329,6 +329,15 @@ def get_fks(request, database):
                 "constraint_name": fk["constraint_name"],
                 "oid": fk["oid"],
                 "name_raw": fk["name_raw"],
+                "column_name": fk["column_name"],
+                "table_name": fk["table_name"],
+                "table_schema": fk["table_schema"],
+                "r_constraint_name": fk["r_constraint_name"],
+                "r_table_name": fk["r_table_name"],
+                "r_table_schema": fk["r_table_schema"],
+                "r_column_name": fk["r_column_name"],
+                "on_update": fk["update_rule"],
+                "on_delete": fk["delete_rule"],
             }
             list_fk.append(fk_data)
     except Exception as exc:

--- a/pgmanage/app/views/tree_sqlite.py
+++ b/pgmanage/app/views/tree_sqlite.py
@@ -103,10 +103,20 @@ def get_pk_columns(request, database):
 @database_required(check_timeout=False, open_connection=True)
 def get_fks(request, database):
     table = request.data["table"]
-
+    list_fk = []
     try:
         fks = database.QueryTablesForeignKeys(table)
-        list_fk = [fk["constraint_name"] for fk in fks.Rows]
+        for fk in fks.Rows:
+            fk_data = {
+                "constraint_name": fk["constraint_name"],
+                "column_name": fk["column_name"],
+                "table_name": fk["table_name"],
+                "r_table_name": fk["r_table_name"],
+                "r_column_name": fk["r_column_name"],
+                "on_update": fk["update_rule"],
+                "on_delete": fk["delete_rule"],
+            }
+            list_fk.append(fk_data)
     except Exception as exc:
         return JsonResponse(data={"data": str(exc)}, status=400)
 


### PR DESCRIPTION
adds drop/add constraint support for postgresql and mysql/mariadb
enhance QueryTablesForeignKeys by adding joins to query information about local and foreign columns
adds read-only constraint support for sqlite3
adds 'change' emit event in SearchableDropdown
