### PR TITLE
707 postgres configuration different locale 

### DIFF
--- a/pgmanage/app/include/OmniDatabase/PostgreSQL.py
+++ b/pgmanage/app/include/OmniDatabase/PostgreSQL.py
@@ -450,6 +450,7 @@ class PostgreSQL:
             where = "WHERE category != 'Preset Options'"
 
         return self.v_connection.Query('''
+        set LC_MESSAGES to 'C';                      
         SELECT name, setting,
       current_setting(name) AS current_setting,
         unit,


### PR DESCRIPTION
sets default lc_messages for configuration queries
fixes: #707 