### PR TITLE
Query results copy with duplicate columns fix

### DIFF
--- a/pgmanage/app/static/pgmanage_frontend/src/components/QueryResultTabs.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/QueryResultTabs.vue
@@ -222,10 +222,21 @@ export default {
 
       let headers = [];
       let headerIndexMap = {}; // Map header titles to their original indices
+      let nameCount = {}; // to track duplicates
+
 
       Object.keys(last(data)).forEach((key) => {
           const originalIndex = parseInt(key, 10);
-          const header = this.columns[originalIndex];
+          let  header = this.columns[originalIndex];
+
+          // Track duplicates
+          if (nameCount[header]) {
+            nameCount[header]++;
+            header = `${header}_${nameCount[header]}`;
+          } else {
+            nameCount[header] = 1;
+          }
+
           headers.push(header);
           headerIndexMap[header] = originalIndex;
       });


### PR DESCRIPTION
appends index to duplicate headers during copy
refs: #712