### PR TITLE
Ssl deprecation fix 

### DIFF
--- a/pgmanage/pgmanage-server.py
+++ b/pgmanage/pgmanage-server.py
@@ -491,8 +491,7 @@ class DjangoApplication(object):
             if parameters['is_ssl']:
                 import ssl
                 ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-                ssl_ctx.options |= ssl.OP_NO_TLSv1
-                ssl_ctx.options |= ssl.OP_NO_TLSv1_1
+                ssl_ctx.minimum_version = ssl.TLSVersion.TLSv1_2
                 ssl_ctx.load_cert_chain(parameters['ssl_certificate_file'],
                                        parameters['ssl_key_file'])
                 v_cherrypy_config['server.ssl_module'] = 'builtin'


### PR DESCRIPTION
adds miminum_version to ssl_ctx to fix deprecation warnings
when running pgmanage-server with ssl enabled there is warnings

> pgmanage-server.py:495: DeprecationWarning: ssl.OP_NO_SSL*/ssl.OP_NO_TLS* options are deprecated
pgmanage-server.py:496: DeprecationWarning: ssl.OP_NO_SSL*/ssl.OP_NO_TLS* options are deprecated

according to https://docs.python.org/3/library/ssl.html#ssl.TLSVersion.MINIMUM_SUPPORTED

> Deprecated since version 3.10: All [TLSVersion](https://docs.python.org/3/library/ssl.html#ssl.TLSVersion) members except [TLSVersion.TLSv1_2](https://docs.python.org/3/library/ssl.html#ssl.TLSVersion.TLSv1_2) and [TLSVersion.TLSv1_3](https://docs.python.org/3/library/ssl.html#ssl.TLSVersion.TLSv1_3) are deprecated.

This fix automatically prevents use of TLS 1.0 and 1.1