### PR TITLE
Data editor grid context menu

### DIFF
--- a/pgmanage/app/static/pgmanage_frontend/src/components/DataEditorTab.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/DataEditorTab.vue
@@ -276,23 +276,6 @@ export default {
           let cellContextMenu = (e, cellComponent) => {
             return [
               {
-                label: '<span>Set Null</span>',
-                action: () => {
-                  contextEdits.add(cellComponent);
-                  cellComponent.setValue(null)
-                }
-              },
-              {
-                label: '<span>Set Empty</span>',
-                action: () => {
-                  contextEdits.add(cellComponent);
-                  cellComponent.setValue("")
-                } 
-              },
-              {
-                separator:true,
-              },
-              {
                 label: '<i class="fas fa-copy"></i><span>Copy</span>',
                 action: function (e, cell) {
                   cell.getTable().copyToClipboard();
@@ -301,23 +284,46 @@ export default {
               {
                 label: '<i class="fas fa-copy"></i><span>Copy as JSON</span>',
                 action: () => {
-                  const data = last(this.table.getRangesData());
+                  const data = last(this.tabulator.getRangesData());
                   this.copyTableData(data, "json", this.columnNames);
                 },
               },
               {
                 label: '<i class="fas fa-copy"></i><span>Copy as CSV</span>',
                 action: () => {
-                  const data = last(this.table.getRangesData());
+                  const data = last(this.tabulator.getRangesData());
                   this.copyTableData(data, "csv", this.columnNames);
                 },
               },
               {
                 label: '<i class="fas fa-copy"></i><span>Copy as Markdown</span>',
                 action: () => {
-                  const data = last(this.table.getRangesData());
+                  const data = last(this.tabulator.getRangesData());
                   this.copyTableData(data, "markdown", this.columnNames);
                 },
+              },
+              {
+                separator:true,
+              },
+              {
+                label: '<span>Set Null</span>',
+                action: () => {
+                  const range = last(this.tabulator.getRanges());
+                  range.getCells().flat().forEach((cell) => {
+                    contextEdits.add(cell);
+                    cell.setValue(null);
+                  })
+                }
+              },
+              {
+                label: '<span>Set Empty</span>',
+                action: () => {
+                  const range = last(this.tabulator.getRanges());
+                  range.getCells().flat().forEach((cell) => {
+                    contextEdits.add(cell);
+                    cell.setValue("");
+                  })
+                } 
               },
             ];
           } 

--- a/pgmanage/app/static/pgmanage_frontend/src/components/DataEditorTab.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/DataEditorTab.vue
@@ -75,7 +75,7 @@ function escapeColumnName(name) {
     : `"${name.replace(/"/g, '""')}"`;
 }
 
-
+const contextEdits = new WeakSet();
 
 export default {
   name: "DataEditorTab",
@@ -275,6 +275,23 @@ export default {
 
           let cellContextMenu = (e, cellComponent) => {
             return [
+              {
+                label: '<span>Set Null</span>',
+                action: () => {
+                  contextEdits.add(cellComponent);
+                  cellComponent.setValue(null)
+                }
+              },
+              {
+                label: '<span>Set Empty</span>',
+                action: () => {
+                  contextEdits.add(cellComponent);
+                  cellComponent.setValue("")
+                } 
+              },
+              {
+                separator:true,
+              },
               {
                 label: '<i class="fas fa-copy"></i><span>Copy</span>',
                 action: function (e, cell) {
@@ -535,8 +552,12 @@ export default {
     cellEdited(cell) {
       if (!this.hasPK)
         return
+
+      const fromContext = contextEdits.has(cell);
+      contextEdits.delete(cell);
+
       // workaround when empty cell with initial null value is changed to empty string when starting editing
-      if (cell.getOldValue() === null && cell.getValue() === '') {
+      if (cell.getOldValue() === null && cell.getValue() === '' && !fromContext) {
         cell.restoreOldValue() // prevents from triggering cellEdited handler again
         return
       }

--- a/pgmanage/app/static/pgmanage_frontend/src/mixins/table_clipboard_copy_mixin.js
+++ b/pgmanage/app/static/pgmanage_frontend/src/mixins/table_clipboard_copy_mixin.js
@@ -1,0 +1,117 @@
+import last from "lodash/last";
+import { settingsStore } from "../stores/stores_initializer";
+
+export default {
+  methods: {
+    copyTableData(data, format, columnNames) {
+      let headers = [];
+      let headerIndexMap = {}; // Map header titles to their original indices
+      let nameCount = {}; // to track duplicates
+
+      Object.keys(last(data)).forEach((key) => {
+        const originalIndex = parseInt(key, 10);
+        let header = columnNames[originalIndex];
+
+        // Track duplicates
+        if (nameCount[header]) {
+          nameCount[header]++;
+          header = `${header}_${nameCount[header]}`;
+        } else {
+          nameCount[header] = 1;
+        }
+
+        headers.push(header);
+        headerIndexMap[header] = originalIndex;
+      });
+
+      if (format === "json") {
+        const jsonOutput = this.generateJson(data, headers, headerIndexMap);
+        this.copyToClipboard(jsonOutput);
+      } else if (format === "csv") {
+        const csvOutput = this.generateCsv(data, headers, headerIndexMap);
+        this.copyToClipboard(csvOutput);
+      } else if (format === "markdown") {
+        const markdownOutput = this.generateMarkdown(
+          data,
+          headers,
+          headerIndexMap
+        );
+        this.copyToClipboard(markdownOutput);
+      }
+    },
+    copyToClipboard(text) {
+      navigator.clipboard
+        .writeText(text)
+        .then(() => {})
+        .catch((error) => {
+          handleError(error);
+        });
+    },
+    generateJson(data, headers, headerIndexMap) {
+      const mappedData = data.map((row) => {
+        const mappedRow = {};
+        headers.forEach((header) => {
+          const originalIndex = headerIndexMap[header];
+          mappedRow[header] = row[originalIndex];
+        });
+        return mappedRow;
+      });
+
+      return JSON.stringify(mappedData, null, 2);
+    },
+    generateCsv(data, headers, headerIndexMap) {
+      const csvRows = [];
+
+      // Add header row
+      csvRows.push(headers.join(settingsStore.csvDelimiter));
+
+      data.forEach((row) => {
+        const rowValues = headers.map((header) => {
+          const originalIndex = headerIndexMap[header];
+          return row[originalIndex] || "";
+        });
+        csvRows.push(rowValues.join(settingsStore.csvDelimiter));
+      });
+
+      return csvRows.join("\n");
+    },
+    generateMarkdown(data, headers, headerIndexMap) {
+      const columnWidths = headers.map((header) => {
+        const originalIndex = headerIndexMap[header];
+        const maxDataLength = data.reduce(
+          (max, row) =>
+            Math.max(max, (row[originalIndex] || "").toString().length),
+          0
+        );
+        return Math.max(header.length, maxDataLength);
+      });
+
+      // Helper to pad strings to a given length
+      const pad = (str, length) => str.toString().padEnd(length, " ");
+
+      const mdRows = [];
+
+      // Add padded header row
+      mdRows.push(
+        `| ${headers
+          .map((header, index) => pad(header, columnWidths[index]))
+          .join(" | ")} |`
+      );
+
+      // Add separator row
+      mdRows.push(
+        `| ${columnWidths.map((width) => "-".repeat(width)).join(" | ")} |`
+      );
+
+      data.forEach((row) => {
+        const rowValues = headers.map((header, index) => {
+          const originalIndex = headerIndexMap[header];
+          return pad(row[originalIndex] || "", columnWidths[index]);
+        });
+        mdRows.push(`| ${rowValues.join(" | ")} |`);
+      });
+
+      return mdRows.join("\n");
+    },
+  },
+};


### PR DESCRIPTION
removes component specific internal variables from mixin
adds data and columnNames arguments to copyTableData method
adds clipboardMixin to DataEditorTab component
adds clipboard functionality to tabulator
adds context menus to data editor cells
adds 'Set Null' and 'Set Empty' context menu options
refs: #743 