### PR TITLE
Bump Node.js version from 18x to 22x

### DIFF
--- a/deploy/linux/tarbuild/Dockerfile
+++ b/deploy/linux/tarbuild/Dockerfile
@@ -49,7 +49,7 @@ COPY --from=build-base /usr/local /usr/local
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates curl npm gnupg patchelf libpq-dev file binutils build-essential
 
 RUN mkdir -p /etc/apt/keyrings && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
 
 RUN apt-get update && apt-get install -y --no-install-recommends nodejs
 

--- a/pgmanage/app/static/pgmanage_frontend/package-lock.json
+++ b/pgmanage/app/static/pgmanage_frontend/package-lock.json
@@ -61,6 +61,9 @@
         "vite": "^5.4.10",
         "vite-plugin-node-polyfills": "^0.22.0",
         "vitest": "^2.1.9"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     ".3.5.13": {

--- a/pgmanage/app/static/pgmanage_frontend/package.json
+++ b/pgmanage/app/static/pgmanage_frontend/package.json
@@ -67,5 +67,8 @@
     "vue": "^3.5.13",
     "vue-simple-password-meter": "^1.3.4",
     "vue-toast-notification": "^3.1.2"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
Since Node.js 18  is out of maintenance from Mar 27, 2025 I think we can update it to version 22.