### PR TITLE
Refactoring/schema editor auto dialect 

### DIFF
--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreeMariaDB.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreeMariaDB.vue
@@ -141,7 +141,7 @@ export default {
             label: "Create Table",
             icon: "fas fa-plus",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.CREATE, "mysql")
+              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.CREATE)
             },
           },
         ],
@@ -168,7 +168,7 @@ export default {
             label: "Alter Table",
             icon: "fas fa-edit",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.UPDATE, "mysql")
+              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.UPDATE)
             },
           },
           {

--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreeMssql.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreeMssql.vue
@@ -215,7 +215,6 @@ export default {
               tabsStore.createSchemaEditorTab(
                 this.selectedNode,
                 operationModes.CREATE,
-                "mssql"
               );
             },
           },
@@ -259,7 +258,6 @@ export default {
               tabsStore.createSchemaEditorTab(
                 this.selectedNode,
                 operationModes.UPDATE,
-                "mssql"
               );
             },
           },

--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreeMysql.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreeMysql.vue
@@ -143,7 +143,7 @@ export default {
             label: "Create Table",
             icon: "fas fa-plus",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.CREATE, "mysql")
+              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.CREATE)
             },
           },
         ],
@@ -170,7 +170,7 @@ export default {
             label: "Alter Table",
             icon: "fas fa-edit",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.UPDATE, "mysql")
+              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.UPDATE)
             },
           },
           {

--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreePostgresql.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreePostgresql.vue
@@ -252,7 +252,7 @@ export default {
             label: "Create Table",
             icon: "fas fa-plus",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.CREATE, "postgres")
+              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.CREATE)
             },
           },
           {
@@ -307,7 +307,7 @@ export default {
             label: "Alter Table",
             icon: "fas fa-edit",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.UPDATE, "postgres")
+              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.UPDATE)
             },
           },
           {

--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreeSqlite.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreeSqlite.vue
@@ -86,7 +86,7 @@ export default {
             label: "Create Table",
             icon: "fas fa-plus",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.CREATE, "sqlite3")
+              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.CREATE)
             },
           },
           {
@@ -117,7 +117,7 @@ export default {
             label: "Alter Table",
             icon: "fas fa-edit",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.UPDATE, "sqlite3")
+              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.UPDATE)
             },
           },
           {

--- a/pgmanage/app/static/pgmanage_frontend/src/constants.js
+++ b/pgmanage/app/static/pgmanage_frontend/src/constants.js
@@ -105,6 +105,7 @@ const editorModeMap = {
   mysql: "mysql_extended",
   mariadb: "mysql_extended",
   oracle: "plsql",
+  mssql: "sqlserver",
 };
 
 const dataEditorFilterModes = {
@@ -129,7 +130,7 @@ const maxFontSize = 20;
 //otherwise - our db technology names match perfectly
 const sqlFormatterDialectMap = {
   oracle: "plsql",
-  mssql: "tsql"
+  mssql: "transactsql"
 }
 
 const knexDialectMap = {

--- a/pgmanage/app/static/pgmanage_frontend/src/main.js
+++ b/pgmanage/app/static/pgmanage_frontend/src/main.js
@@ -13,6 +13,7 @@ import 'ace-builds/src-noconflict/mode-plsql'
 import 'ace-builds/src-noconflict/mode-json';
 import 'ace-builds/src-noconflict/mode-plain_text';
 import 'ace-builds/src-noconflict/mode-xml';
+import 'ace-builds/src-noconflict/mode-sqlserver';
 import 'ace-builds/src-noconflict/ext-language_tools'
 import 'ace-builds/src-noconflict/ext-searchbox'
 import 'ace-builds/src-noconflict/worker-json';

--- a/pgmanage/app/static/pgmanage_frontend/src/stores/tabs.js
+++ b/pgmanage/app/static/pgmanage_frontend/src/stores/tabs.js
@@ -654,7 +654,7 @@ const useTabsStore = defineStore("tabs", {
 
       this.selectTab(tab);
     },
-    createSchemaEditorTab(node, mode, dialect) {
+    createSchemaEditorTab(node, mode) {
       let tableName = node.title.replace(/^"(.*)"$/, "$1");
 
       let tabTitle =
@@ -680,17 +680,13 @@ const useTabsStore = defineStore("tabs", {
 
       tab.metaData.dialect = this.selectedPrimaryTab?.metaData?.selectedDBMS;
       tab.metaData.editMode = mode;
-      tab.metaData.schema =
-        dialect === "mysql" ? node.data.database : node.data.schema;
+      tab.metaData.schema = ["mysql", "mariadb"].includes(this.selectedPrimaryTab.metaData.selectedDBMS) ? node.data.database : node.data.schema;
       tab.metaData.table = mode === operationModes.UPDATE ? tableName : null;
       tab.metaData.treeNode = node;
       tab.metaData.databaseIndex =
         this.selectedPrimaryTab?.metaData?.selectedDatabaseIndex;
 
-      tab.metaData.databaseName =
-        dialect === "mysql"
-          ? node.data.database
-          : this.selectedPrimaryTab?.metaData?.selectedDatabase;
+      tab.metaData.databaseName = ["mysql", "mariadb"].includes(this.selectedPrimaryTab.metaData.selectedDBMS) ? node.data.database : this.selectedPrimaryTab?.metaData?.selectedDatabase;
 
       this.selectTab(tab);
     },

--- a/pgmanage/app/static/pgmanage_frontend/src/stores/tabs.js
+++ b/pgmanage/app/static/pgmanage_frontend/src/stores/tabs.js
@@ -655,18 +655,15 @@ const useTabsStore = defineStore("tabs", {
       this.selectTab(tab);
     },
     createSchemaEditorTab(node, mode) {
-      let tableName = node.title.replace(/^"(.*)"$/, "$1");
-
-      let tabTitle =
-        mode === operationModes.UPDATE ? `Alter: ${tableName}` : "New Table";
-      let icon = `<i class="fas ${
-        mode === operationModes.CREATE ? "fa-plus" : "fa-edit"
-      } icon-tab-title"></i>`;
+      const isCreate = mode === operationModes.CREATE;
+      const tableName = node.title.replace(/^"(.*)"$/, "$1");
+      const tabTitle = isCreate ? "New Table" : `Alter: ${tableName}`;
+      const iconClass = isCreate ? "fa-plus" : "fa-edit";
 
       const tab = this.addTab({
         parentId: this.selectedPrimaryTab.id,
         name: tabTitle,
-        icon: icon,
+        icon: `<i class="fas ${iconClass} icon-tab-title"></i>`,
         component: "SchemaEditorTab",
         mode: "alter",
         closeFunction: (e, tab) => {
@@ -678,15 +675,17 @@ const useTabsStore = defineStore("tabs", {
         },
       });
 
-      tab.metaData.dialect = this.selectedPrimaryTab?.metaData?.selectedDBMS;
-      tab.metaData.editMode = mode;
-      tab.metaData.schema = ["mysql", "mariadb"].includes(this.selectedPrimaryTab.metaData.selectedDBMS) ? node.data.database : node.data.schema;
-      tab.metaData.table = mode === operationModes.UPDATE ? tableName : null;
-      tab.metaData.treeNode = node;
-      tab.metaData.databaseIndex =
-        this.selectedPrimaryTab?.metaData?.selectedDatabaseIndex;
+      const { metaData } = this.selectedPrimaryTab;
 
-      tab.metaData.databaseName = ["mysql", "mariadb"].includes(this.selectedPrimaryTab.metaData.selectedDBMS) ? node.data.database : this.selectedPrimaryTab?.metaData?.selectedDatabase;
+      Object.assign(tab.metaData, {
+        dialect: metaData.selectedDBMS,
+        editMode: mode,
+        treeNode: node,
+        databaseIndex: metaData.selectedDatabaseIndex,
+        table: isCreate ? null : tableName,
+        schema: node.data.schema || node.data.database,
+        databaseName: metaData.selectedDatabase
+      });
 
       this.selectTab(tab);
     },


### PR DESCRIPTION
removes explicit dialect parameter and infer from selected DBMS
adds MSSQL Ace editor mode
update SQL formatter dialect mapping for MSSQL
normalize schema/database detection for MySQL and MariaDB