### PR TITLE
add keyboard navigation support for context menus in DB Explorer

### DIFF
--- a/pgmanage/app/static/pgmanage_frontend/src/assets/scss/libs/context-menu-pgmanage.scss
+++ b/pgmanage/app/static/pgmanage_frontend/src/assets/scss/libs/context-menu-pgmanage.scss
@@ -27,8 +27,9 @@
             }
         }
 
-        &:hover:not(.disabled), &.open {
+        &:hover:not(.disabled), &.open, &.keyboard-focus {
             background-color: rgba($primaryBlue, 0.15);
+            outline: none;
         }
 
         .mx-right-arrow {
@@ -67,5 +68,35 @@
                 background-color: themed($borderColor);
             }
         }
+    }
+
+    @keyframes collapseSafeOverlay {
+        0% {
+            left: -80px;
+        }
+        85% {
+            left: -80px;
+        }
+        100% {
+            left: 0;
+        }
+    }
+
+    // the following block allos to move mouse pointer diagonally
+    // from the parent menu to submenu, the idea is that
+    // we have an overlay pseudoelement near submenu which blocks hover
+    // events over other parent menu items. the overlay shrinks after a delay
+    // so that it does not get in the way for hovering over parent menu items
+    .mx-context-menu.diagonal-safe-menu:not(.mx-menu-host)::before {
+        content: '';
+        position: absolute;
+        top: -30px;
+        bottom: -30px;
+        left: -80px;
+        right: 15px;
+        z-index: -1;
+        background: transparent; 
+        animation: collapseSafeOverlay 0.5s forwards linear;
+        pointer-events: auto !important;
     }
 }

--- a/pgmanage/app/static/pgmanage_frontend/src/mixins/power_tree.js
+++ b/pgmanage/app/static/pgmanage_frontend/src/mixins/power_tree.js
@@ -8,21 +8,12 @@ import { handleError } from "../logging/utils";
 import { h } from "vue";
 import debounce from "lodash/debounce";
 
-let hoverTimer = null;
-
-function delayedEnter(fn, delay = 220) {
-  return (e) => {
-    if (hoverTimer) clearTimeout(hoverTimer);
-
-    hoverTimer = setTimeout(() => fn(e), delay);
-  };
-}
-
 export default {
   emits: ["treeTabsUpdate", "clearTabs"],
   data() {
     return {
       selectedDatabase: tabsStore.selectedPrimaryTab.metaData.selectedDatabase,
+      treeContextMenuOpen: false,
     };
   },
   computed: {
@@ -115,52 +106,10 @@ export default {
           y: e.y,
           zIndex: 1000,
           minWidth: 230,
+          keyboardControl: true,
+          customClass: 'diagonal-safe-menu',
           items: this.contextMenu[node.data.contextMenu],
-        },
-        {
-          itemRender: ({
-            disabled,
-            label,
-            icon,
-            showRightArrow,
-            onClick,
-            onMouseEnter,
-          }) =>
-            h(
-              "div",
-              {
-                class: ["mx-context-menu-item", disabled ? "disabled" : ""],
-                onClick,
-                onMouseenter: delayedEnter(onMouseEnter, 200),
-              },
-              [
-                h("div", { class: "mx-item-row" }, [
-                  h("div", { class: "mx-icon-placeholder preserve-width" }, [
-                    icon
-                      ? h("i", { class: [icon, "icon",] })
-                      : h("span", { class: "mx-content-menu-icon" }),
-                  ]),
-                  h("span", { class: "label" }, label),
-                ]),
-                showRightArrow
-                  ? h("div", { class: "mx-item-row" }, [
-                      h(
-                        "svg",
-                        {
-                          class: "mx-right-arrow",
-                          "aria-hidden": "true",
-                          viewBox: "0 0 1024 1024",
-                        },
-                        [
-                          h("path", {
-                            d: "M307.018 49.445c11.517 0 23.032 4.394 31.819 13.18L756.404 480.18c8.439 8.438 13.181 19.885 13.181 31.82s-4.741 23.38-13.181 31.82L338.838 961.376c-17.574 17.573-46.065 17.573-63.64-0.001-17.573-17.573-17.573-46.065 0.001-63.64L660.944 512 275.198 126.265c-17.574-17.573-17.574-46.066-0.001-63.64C283.985 53.839 295.501 49.445 307.018 49.445z",
-                          }),
-                        ]
-                      ),
-                    ])
-                  : null,
-              ]
-            ),
+          onClose: () => {this.treeContextMenuOpen = false}
         }
       );
     },
@@ -358,6 +307,8 @@ export default {
       }
     },
     handleTreeKeyboardNavigation(event) {
+      if(this.treeContextMenuOpen)
+        return;
       const keyCode = event.code;
       const tree = this.$refs.tree;
       
@@ -456,6 +407,7 @@ export default {
             });
 
             this.onContextMenu(selectedNode, fakeEvent);
+            this.treeContextMenuOpen = true;
             return;
           }
           return;


### PR DESCRIPTION
integrates with handleTreeKeyboardNavigation so they don't fight each other
removes "diagonal mouse move" delay workaround implemented in custom item renderer, replace it with CSS-baed hover overlays for submenus adjust context menu item styles to hide "keyboard focus" outline and background

refs: #746