### PR TITLE
Refactor schema editor tab creation arguments

### DIFF
--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreeMariaDB.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreeMariaDB.vue
@@ -141,7 +141,8 @@ export default {
             label: "Create Table",
             icon: "fas fa-plus",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.CREATE)
+              const nodeDatabase = this.getNodeDatabase(this.selectedNode);
+              tabsStore.createSchemaEditorTab(this.selectedNode.title, nodeDatabase, operationModes.CREATE);
             },
           },
         ],
@@ -168,7 +169,8 @@ export default {
             label: "Alter Table",
             icon: "fas fa-edit",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.UPDATE)
+              const nodeDatabase = this.getNodeDatabase(this.selectedNode);
+              tabsStore.createSchemaEditorTab(this.selectedNode.title, nodeDatabase, operationModes.UPDATE);
             },
           },
           {

--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreeMssql.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreeMssql.vue
@@ -213,7 +213,8 @@ export default {
             icon: "fas fa-plus",
             onClick: () => {
               tabsStore.createSchemaEditorTab(
-                this.selectedNode,
+                this.selectedNode.title,
+                this.selectedNode.data.schema,
                 operationModes.CREATE,
               );
             },
@@ -256,7 +257,8 @@ export default {
             icon: "fas fa-edit",
             onClick: () => {
               tabsStore.createSchemaEditorTab(
-                this.selectedNode,
+                this.selectedNode.title,
+                this.selectedNode.data.schema,
                 operationModes.UPDATE,
               );
             },

--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreeMysql.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreeMysql.vue
@@ -143,7 +143,8 @@ export default {
             label: "Create Table",
             icon: "fas fa-plus",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.CREATE)
+              const nodeDatabase = this.getNodeDatabase(this.selectedNode);
+              tabsStore.createSchemaEditorTab(this.selectedNode.title, nodeDatabase, operationModes.CREATE);
             },
           },
         ],
@@ -170,7 +171,8 @@ export default {
             label: "Alter Table",
             icon: "fas fa-edit",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.UPDATE)
+              const nodeDatabase = this.getNodeDatabase(this.selectedNode);
+              tabsStore.createSchemaEditorTab(this.selectedNode.title, nodeDatabase, operationModes.UPDATE);
             },
           },
           {

--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreeOracle.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreeOracle.vue
@@ -86,7 +86,7 @@ export default {
             label: "Create Table",
             icon: "fas fa-plus",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.CREATE)
+              tabsStore.createSchemaEditorTab(this.selectedNode.title, this.selectedNode.data.schema, operationModes.CREATE);
             },
           },
         ],
@@ -113,7 +113,7 @@ export default {
             label: "Alter Table",
             icon: "fas fa-edit",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.UPDATE)
+              tabsStore.createSchemaEditorTab(this.selectedNode.title, this.selectedNode.data.schema, operationModes.UPDATE);
             },
           },
           {

--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreePostgresql.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreePostgresql.vue
@@ -256,7 +256,7 @@ export default {
             label: "Create Table",
             icon: "fas fa-plus",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.CREATE)
+              tabsStore.createSchemaEditorTab(this.selectedNode.title, this.selectedNode.data.schema, operationModes.CREATE);
             },
           },
           {
@@ -311,7 +311,7 @@ export default {
             label: "Alter Table",
             icon: "fas fa-edit",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.UPDATE)
+              tabsStore.createSchemaEditorTab(this.selectedNode.title, this.selectedNode.data.schema, operationModes.UPDATE);
             },
           },
           {

--- a/pgmanage/app/static/pgmanage_frontend/src/components/TreeSqlite.vue
+++ b/pgmanage/app/static/pgmanage_frontend/src/components/TreeSqlite.vue
@@ -86,7 +86,7 @@ export default {
             label: "Create Table",
             icon: "fas fa-plus",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.CREATE)
+              tabsStore.createSchemaEditorTab(this.selectedNode.title, null, operationModes.CREATE)
             },
           },
           {
@@ -117,7 +117,7 @@ export default {
             label: "Alter Table",
             icon: "fas fa-edit",
             onClick: () => {
-              tabsStore.createSchemaEditorTab(this.selectedNode, operationModes.UPDATE)
+              tabsStore.createSchemaEditorTab(this.selectedNode.title, null, operationModes.UPDATE)
             },
           },
           {

--- a/pgmanage/app/static/pgmanage_frontend/src/stores/tabs.js
+++ b/pgmanage/app/static/pgmanage_frontend/src/stores/tabs.js
@@ -655,9 +655,9 @@ const useTabsStore = defineStore("tabs", {
 
       this.selectTab(tab);
     },
-    createSchemaEditorTab(node, mode) {
+    createSchemaEditorTab(title, schema, mode) {
       const isCreate = mode === operationModes.CREATE;
-      const tableName = node.title.replace(/^"(.*)"$/, "$1");
+      const tableName = title.replace(/^"(.*)"$/, "$1");
       const tabTitle = isCreate ? "New Table" : `Alter: ${tableName}`;
       const iconClass = isCreate ? "fa-plus" : "fa-edit";
 
@@ -683,7 +683,7 @@ const useTabsStore = defineStore("tabs", {
         editMode: mode,
         databaseIndex: metaData.selectedDatabaseIndex,
         table: isCreate ? null : tableName,
-        schema: node.data.schema || node.data.database,
+        schema: schema,
         databaseName: metaData.selectedDatabase
       });
 

--- a/pgmanage/app/static/pgmanage_frontend/test/components/TreeSqlite.test.js
+++ b/pgmanage/app/static/pgmanage_frontend/test/components/TreeSqlite.test.js
@@ -154,7 +154,8 @@ describe("TreeSqlite.vue", () => {
     wrapper.vm.contextMenu.cm_tables[1].onClick();
 
     expect(tabsStore.createSchemaEditorTab).toHaveBeenCalledWith(
-      wrapper.vm.selectedNode,
+      wrapper.vm.selectedNode.title,
+      null,
       operationModes.CREATE,
     );
   });
@@ -201,7 +202,8 @@ describe("TreeSqlite.vue", () => {
     wrapper.vm.contextMenu.cm_table[3].onClick();
 
     expect(tabsStore.createSchemaEditorTab).toHaveBeenCalledWith(
-      wrapper.vm.selectedNode,
+      wrapper.vm.selectedNode.title,
+      null,
       operationModes.UPDATE,
     );
   });

--- a/pgmanage/app/static/pgmanage_frontend/test/stores/tabs.test.js
+++ b/pgmanage/app/static/pgmanage_frontend/test/stores/tabs.test.js
@@ -360,11 +360,13 @@ describe("useTabsStore", () => {
     const primaryTab = store.addTab({ name: "Primary Tab" });
     store.selectTab(primaryTab);
     store.selectedPrimaryTab.metaData.selectedDBMS = "mysql";
+    const nodeMock = {
+      title: "test_table",
+      data: { schema: "TestSchema", database: "TestDB" },
+    };
     store.createSchemaEditorTab(
-      {
-        title: "test_table",
-        data: { schema: "TestSchema", database: "TestDB" },
-      },
+      nodeMock.title,
+      nodeMock.data.database,
       operationModes.CREATE,
     );
 


### PR DESCRIPTION
update createSchemaEditorTab to accept the table title and schema directly instead of passing the full tree node object
updates related tests

fixes broken schema editor for mysql/mariadb dialects